### PR TITLE
Added and configured enzyme-adapter

### DIFF
--- a/test/root.js
+++ b/test/root.js
@@ -1,17 +1,21 @@
-require('babel-register')();
+require("babel-register")();
+import { configure } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
 
-var exposedProperties = ['window', 'navigator', 'document'];
+configure({ adapter: new Adapter() });
 
-var jsdom = require('jsdom').jsdom;
+var exposedProperties = ["window", "navigator", "document"];
 
-global.document = jsdom('');
+var jsdom = require("jsdom").jsdom;
+
+global.document = jsdom("");
 global.window = document.defaultView;
-Object.keys(document.defaultView).forEach((property) => {
-  if (typeof global[property] === 'undefined') {
+Object.keys(document.defaultView).forEach(property => {
+  if (typeof global[property] === "undefined") {
     global[property] = document.defaultView[property];
   }
 });
 
 global.navigator = {
-  userAgent: 'node.js'
+  userAgent: "node.js"
 };


### PR DESCRIPTION
When they try to run the test files, students get the error message:
```
     Error: 
      Enzyme Internal Error: Enzyme expects an adapter to be configured, but found none.
```
Following the instructions in the Enzyme doc, I added the enzyme-adapter so the test run correctly.